### PR TITLE
Adds entity module and plane

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: rust
+rust:
+    - 1.29.1
+    - stable
+script:
+    - cargo build --verbose --all
+    - cargo test --verbose --all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,4 @@
+[[package]]
+name = "gentle-ap-physics-rs"
+version = "0.1.0"
+

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -1,0 +1,59 @@
+pub mod plane;
+
+pub trait BaseEntity {
+    fn set_entity_state(&mut self, EntityState);
+    fn get_entity_state(&self) -> &EntityState;
+    fn get_mass(&self) -> f32;
+    fn get_next_state();
+}
+
+pub trait RoundedEntity {
+    fn get_moment_inertia() -> f64;
+}
+
+#[derive(Debug)]
+pub struct EntityState {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+impl EntityState {
+    pub fn new(x: f32, y: f32, z: f32) -> EntityState {
+        return EntityState { x: x, y: y, z: z };
+    }
+}
+
+impl Clone for EntityState {
+    fn clone(&self) -> EntityState {
+        EntityState {
+            x: self.x,
+            y: self.y,
+            z: self.z,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn it_creates_state() {
+        let state = EntityState::new(1.0, 2.0, 3.0);
+        assert_eq!(state.x, 1.0);
+        assert_eq!(state.y, 2.0);
+        assert_eq!(state.z, 3.0);
+    }
+
+    #[test]
+    fn it_clones_state() {
+        let state = EntityState::new(1.0, 2.0, 3.0);
+        assert_eq!(state.x, 1.0);
+        let mut cloned_state = state.clone();
+        assert_eq!(state.x, cloned_state.x);
+        assert_eq!(state.y, cloned_state.y);
+        assert_eq!(state.z, cloned_state.z);
+        cloned_state.x = 4.0;
+        assert_ne!(state.x, cloned_state.x);
+    }
+}

--- a/src/entity/plane.rs
+++ b/src/entity/plane.rs
@@ -1,0 +1,51 @@
+use entity;
+
+#[derive(Debug)]
+pub struct Plane {
+  state: entity::EntityState,
+  mass: f32,
+  width: f32,
+  length: f32,
+}
+
+impl Plane {
+  pub fn new(state: entity::EntityState, mass: f32, width: f32, length: f32) -> Plane {
+    return Plane {
+      state: state,
+      mass: mass,
+      width: width,
+      length: length,
+    };
+  }
+}
+
+impl entity::BaseEntity for Plane {
+  fn set_entity_state(&mut self, state: entity::EntityState) {
+    self.state = state.clone();
+  }
+
+  fn get_entity_state(&self) -> &entity::EntityState {
+    &self.state
+  }
+
+  fn get_mass(&self) -> f32 {
+    return self.mass;
+  }
+
+  fn get_next_state() {}
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use entity::BaseEntity;
+  #[test]
+  fn it_creates_a_plane() {
+    let state = entity::EntityState::new(3.0, 3.0, 4.0);
+    let plane = Plane::new(state.clone(), 5.0, 1.0, 2.0);
+    let ent_state = plane.get_entity_state();
+    assert_eq!(ent_state.x, state.x);
+    assert_eq!(ent_state.y, state.y);
+    assert_eq!(ent_state.z, state.z);
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+mod entity;
+
 fn main() {
-    println!("Hello, world!");
+    let state = entity::EntityState::new(1.0, 2.0, 3.0);
+    let plane = entity::plane::Plane::new(state.clone(), 1.0, 2.0, 4.0);
+    println!("{:?}", state);
+    println!("{:?}", plane);
 }


### PR DESCRIPTION
Creates a simple `BaseEntity` and a `Plane` along with an `EntityState` that defines some current mutable properties for any entity. `RoundedEntity` is included but is not implemented. Tests are written in the test mod included with every file.