### PR TITLE
Collision physics

### DIFF
--- a/src/entity/sphere.rs
+++ b/src/entity/sphere.rs
@@ -1,5 +1,6 @@
 use entity;
 use entity::Entity;
+use entity::BaseEntity;
 use util::math;
 use util::vector3::Vector3;
 
@@ -54,6 +55,16 @@ impl Sphere {
 
     pub fn get_radius(&self) -> f32 {
         self.radius
+    }
+
+    pub fn collide_with_sphere (&mut self, mut other: &mut Sphere) {
+        let force = math::calculate_impulse_force (&self, &other);
+        self.apply_force (force);
+        other.apply_force (force * -1.0);
+    }
+
+    pub fn get_velocity(&self) -> Vector3 {
+        self.velocity
     }
 }
 

--- a/src/entity/sphere.rs
+++ b/src/entity/sphere.rs
@@ -1,6 +1,7 @@
 use entity;
 use entity::Entity;
 use entity::BaseEntity;
+use entity::plane::Plane;
 use util::math;
 use util::vector3::Vector3;
 
@@ -58,9 +59,14 @@ impl Sphere {
     }
 
     pub fn collide_with_sphere (&mut self, mut other: &mut Sphere) {
-        let force = math::calculate_impulse_force (&self, &other);
+        let force = math::calculate_impulse_force_between_spheres (&self, &other);
         self.apply_force (force);
         other.apply_force (force * -1.0);
+    }
+
+    pub fn collide_with_plane (&mut self, other: Plane) {
+        let force = math::calculate_impulse_force_sphere_plane (&self, &other);
+        self.apply_force (force);
     }
 
     pub fn get_velocity(&self) -> Vector3 {

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -1,7 +1,10 @@
 use super::vector3::Vector3;
+use entity::sphere::Sphere;
+use entity::BaseEntity;
 
 const COEFFICIENT_OF_FRICTION: f32 = 0.05;
 const ACC_GRAVITY: f32 = 9.8;
+const COEFFICITION_OF_RESTITUTION_SPHERE: f32 = 1.0;
 
 pub fn friction(f: f32) -> f32 {
     COEFFICIENT_OF_FRICTION * f
@@ -55,6 +58,15 @@ pub fn detect_collide_sphere_to_plane(center: Vector3, radius: f32, bmin: Vector
     }
 
     return dmin <= (radius).powf(2.0);
+}
+
+pub fn calculate_impulse_force(sphere1: &Sphere, sphere2: &Sphere) -> Vector3 {
+    //finally found formula at
+    //https://www.gamasutra.com/view/feature/3168/physics_on_the_back_of_a_cocktail_.php?print=1
+    let relative_velocity = sphere1.get_velocity() - sphere2.get_velocity();
+    let dir_of_impact = Vector3::new(sphere2.get_position().x - sphere1.get_position().x, sphere2.get_position().y - sphere1.get_position().y, sphere1.get_position().z - sphere2.get_position().z).normalized();
+    let numerator = (relative_velocity * -(1.0 + COEFFICITION_OF_RESTITUTION_SPHERE)).dot_product(dir_of_impact);
+    return dir_of_impact * (numerator * (1.0 / ((1.0 / sphere1.get_mass()) + (1.0 / sphere2.get_mass ()))));
 }
 
 #[cfg(test)]

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -1,10 +1,12 @@
 use super::vector3::Vector3;
 use entity::sphere::Sphere;
+use entity::plane::Plane;
 use entity::BaseEntity;
+
 
 const COEFFICIENT_OF_FRICTION: f32 = 0.05;
 const ACC_GRAVITY: f32 = 9.8;
-const COEFFICITION_OF_RESTITUTION_SPHERE: f32 = 1.0;
+const COEFFICIENT_OF_RESTITUTION: f32 = 0.5;
 
 pub fn friction(f: f32) -> f32 {
     COEFFICIENT_OF_FRICTION * f
@@ -60,13 +62,29 @@ pub fn detect_collide_sphere_to_plane(center: Vector3, radius: f32, bmin: Vector
     return dmin <= (radius).powf(2.0);
 }
 
-pub fn calculate_impulse_force(sphere1: &Sphere, sphere2: &Sphere) -> Vector3 {
+pub fn calculate_impulse_force_between_spheres(sphere1: &Sphere, sphere2: &Sphere) -> Vector3 {
     //finally found formula at
     //https://www.gamasutra.com/view/feature/3168/physics_on_the_back_of_a_cocktail_.php?print=1
     let relative_velocity = sphere1.get_velocity() - sphere2.get_velocity();
+    
+    //direction that sphere1 collides with sphere2
     let dir_of_impact = Vector3::new(sphere2.get_position().x - sphere1.get_position().x, sphere2.get_position().y - sphere1.get_position().y, sphere1.get_position().z - sphere2.get_position().z).normalized();
-    let numerator = (relative_velocity * -(1.0 + COEFFICITION_OF_RESTITUTION_SPHERE)).dot_product(dir_of_impact);
+
+    let numerator = (relative_velocity * -(1.0 + COEFFICIENT_OF_RESTITUTION)).dot_product(dir_of_impact);
     return dir_of_impact * (numerator * (1.0 / ((1.0 / sphere1.get_mass()) + (1.0 / sphere2.get_mass ()))));
+}
+
+pub fn calculate_impulse_force_sphere_plane (sphere: &Sphere, plane: &Plane) -> Vector3 {
+    //for now plane can't move
+    let vel = sphere.get_velocity();
+
+    //for now sphere can only collide with plane going straight down
+    let dir_of_impact = Vector3::new (0.0, -1.0, 0.0);      
+
+    let numerator = (vel * -(1.0 + COEFFICIENT_OF_RESTITUTION)).dot_product(dir_of_impact);
+
+    //for not simulating mass of plane as infinite
+    return dir_of_impact * (numerator * (1.0 / (1.0 / sphere.get_mass())));
 }
 
 #[cfg(test)]

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -125,6 +125,14 @@ mod tests {
     assert_eq!(false, detect_collide_sphere_to_sphere(src, dst, 0.0, 0.0));
   }
 
+  #[test]
+  fn it_calc_force_sphere_plane_collision (){
+    let sphere1 = Sphere::new ("Sphere1", Vector3::new(0.0, 1.0, 0.0), 1.0, 1.0, Vector3::new(0.0, -1.0, 0.0));
+    let plane1 = Plane::new ("Plane1", Vector3:new(0.0, 0.0, 0.0), 1.0, 10.0, 10.0);
+    let force = calculate_impulse_force_sphere_plane (&sphere1, &plane1);
+    assert_eq!(force, Vector3::new(0, 0.5, 0.0);
+  }
+
   /* tested elsewhere now
   #[test]
   fn it_calc_detect_collide_sphere_to_plane() {

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -125,12 +125,21 @@ mod tests {
     assert_eq!(false, detect_collide_sphere_to_sphere(src, dst, 0.0, 0.0));
   }
 
+  #[test] 
+  fn it_calc_force_sphere_sphere_collision () {
+    let sphere1 = Sphere::new (String::from("Sphere1"), Vector3::new(0.0, 0.0, 0.0), 1.0, 1.0, Vector3::new(1.0, 0.0, 0.0));
+    let sphere2 = Sphere::new (String::from("Sphere2"), Vector3::new(1.0, 0.0, 0.0), 1.0, 1.0, Vector3::new (0.0, 0.0, 0.0));
+    let force = calculate_impulse_force_between_spheres (&sphere1, &sphere2);
+    assert_eq!(force, Vector3::new(-(0.25 + COEFFICIENT_OF_RESTITUTION), 0.0, 0.0));
+
+  }
+
   #[test]
   fn it_calc_force_sphere_plane_collision (){
-    let sphere1 = Sphere::new ("Sphere1", Vector3::new(0.0, 1.0, 0.0), 1.0, 1.0, Vector3::new(0.0, -1.0, 0.0));
-    let plane1 = Plane::new ("Plane1", Vector3:new(0.0, 0.0, 0.0), 1.0, 10.0, 10.0);
+    let sphere1 = Sphere::new (String::from("Sphere1"), Vector3::new(0.0, 1.0, 0.0), 1.0, 1.0, Vector3::new(0.0, -1.0, 0.0));
+    let plane1 = Plane::new (String::from("Plane1"), Vector3::new(0.0, 0.0, 0.0), 1.0, 10.0, 10.0);
     let force = calculate_impulse_force_sphere_plane (&sphere1, &plane1);
-    assert_eq!(force, Vector3::new(0, 0.5, 0.0);
+    assert_eq!(force, Vector3::new(0.0, 1.0 + COEFFICIENT_OF_RESTITUTION, 0.0));
   }
 
   /* tested elsewhere now

--- a/src/util/vector3.rs
+++ b/src/util/vector3.rs
@@ -62,4 +62,17 @@ impl Vector3 {
     pub fn new(x: f32, y: f32, z: f32) -> Vector3 {
         return Vector3 { x: x, y: y, z: z };
     }
+
+    pub fn magnitude (&self) -> f32 {
+        return (self.x * self.x + self.y * self.y + self.z * self.z).sqrt();
+    }
+
+    pub fn normalized (&self) -> Vector3 {
+        let mag = self.magnitude();
+        return Vector3::new (self.x / mag, self.y / mag, self.z / mag);
+    }
+
+    pub fn dot_product (&self, other: Vector3) -> f32 {
+        return self.x * other.x + self.y * other.y + self.z * other.z;
+    }
 }


### PR DESCRIPTION
Implemented collision physics math between two spheres and between a sphere and a plane. Next step is to make sure these are used during the worldstate update step.

Sphere and plane collision math is a placeholder until we change plane to include a surface normal (ie we can tilt the plane).